### PR TITLE
Remove obsolete closing brace comment

### DIFF
--- a/assets/js/autocomplete-sok.js
+++ b/assets/js/autocomplete-sok.js
@@ -179,5 +179,4 @@ visAlleKnapp?.addEventListener("click", () => {
   }
 });
 
-// <-- Add this closing brace to end the DOMContentLoaded event listener function
 });


### PR DESCRIPTION
## Summary
- remove leftover comment at the end of `autocomplete-sok.js`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685f8a6c206483259b78762f0ebaf683