### PR TITLE
Add pytest tests for Flask API

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ Jeg er en norsk utvikler med lidenskap for **strukturert kode**, **brukervennlig
 
 ---
 
+## 🧪 Testing
+
+For å kjøre de automatiske testene av Flask-serveren bruker du [pytest](https://pytest.pypi.org/).
+Installer eventuelt avhengigheter og kjør deretter:
+
+```bash
+pytest
+```
+
+---
+
 ## 📬 Kontakt
 
 Har du spørsmål, forslag eller vil samarbeide?  

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,30 @@
+import json
+from unittest.mock import patch, Mock
+
+import pytest
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'Admin'))
+
+from server import app
+
+
+def test_meta_description_returned():
+    html = '<html><head><meta name="description" content="Test desc"></head></html>'
+    mock_response = Mock()
+    mock_response.text = html
+
+    with patch('server.requests.get', return_value=mock_response):
+        client = app.test_client()
+        resp = client.get('/api/meta?url=http://example.com')
+        assert resp.status_code == 200
+        assert resp.get_json() == {"description": "Test desc"}
+
+
+def test_invalid_url_returns_400():
+    client = app.test_client()
+    resp = client.get('/api/meta?url=invalid-url')
+    assert resp.status_code == 400
+


### PR DESCRIPTION
## Summary
- add unit tests for Flask `api_meta` endpoint
- document how to run the tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685f8cfae0e0832587e3aa82956c5dd6